### PR TITLE
chore(docs): add AWS IAM & networking plan

### DIFF
--- a/docs/aws-iam.md
+++ b/docs/aws-iam.md
@@ -1,0 +1,15 @@
+# AWS IAM Setup
+
+This document records the IAM configuration for our `devops-junior` user.
+
+- **User ARN:** arn:aws:iam::847179581003:user/devops-junior
+- **Attached Policies:**
+  - AmazonEC2ContainerRegistryFullAccess
+  - AmazonECS_FullAccess
+  - AmazonRDSFullAccess
+  - AmazonS3FullAccess
+  - CloudWatchLogsFullAccess
+
+> **Notes:**
+> - This user is used by GitHub Actions and local CLI to provision infra and deploy containers.
+> - No permissions to manage IAM itself, billing, or other AWS services.

--- a/docs/aws-networking.md
+++ b/docs/aws-networking.md
@@ -1,0 +1,29 @@
+# AWS Networking Plan
+
+Below is the proposed network design for Premium Notes App:
+
+- **VPC**
+  - CIDR: `10.0.0.0/16`
+
+- **Subnets**
+  - Public Subnets (for ALB):
+    - `10.0.1.0/24` (AZ-a)
+    - `10.0.2.0/24` (AZ-b)
+  - Private Subnets (for ECS & RDS):
+    - `10.0.101.0/24` (AZ-a)
+    - `10.0.102.0/24` (AZ-b)
+
+- **Internet Gateway & Route Tables**
+  - Public subnets route `0.0.0.0/0` to IGW.
+  - Private subnets use NAT gateway in public subnet (if external outbound is required).
+
+- **Security Groups**
+  - **ALB SG**:
+    - Inbound: `TCP 80,443` from `0.0.0.0/0`
+    - Outbound: all traffic
+  - **ECS Tasks SG**:
+    - Inbound: `TCP 80` or `5000` from ALB SG
+    - Outbound: all traffic
+  - **RDS SG**:
+    - Inbound: `TCP 5432` from ECS Tasks SG
+    - Outbound: all traffic


### PR DESCRIPTION
## What
Adds two new docs under `docs/`:
- `aws-iam.md`: Records the devops-junior IAM user ARN and attached policies.
- `aws-networking.md`: Details the planned VPC CIDR, subnets, route tables, and security groups.

## Why
- Documents required AWS permissions and network setup before writing Terraform.
- Ensures clarity and prevents mistakes in infra code.

## How to review
1. Verify IAM user ARN & policies are correct.
2. Confirm network CIDR blocks and SG rules align with best practices.
3. Suggest adjustments for AZ distribution or NAT use.